### PR TITLE
refactor: input fields

### DIFF
--- a/example/lib/modules/components/input_fields.dart
+++ b/example/lib/modules/components/input_fields.dart
@@ -18,6 +18,10 @@ class InputFieldsComponentShowcase extends StatelessWidget {
             label: 'Color',
             builder: (_) => _StoryContainer(child: _ColorPickers()),
           ),
+          FDChipGroupViewPage(
+            label: 'Combined',
+            builder: (_) => _StoryContainer(child: _CombinedFields()),
+          ),
         ],
       ),
     );
@@ -71,25 +75,41 @@ class _TextFields extends StatelessWidget {
           hintText: 'Enter team name',
           autofocus: true,
         ),
+        FDTextField(
+          id: 'name-focused',
+          label: 'LONG LABELED FIELD',
+          onChanged: (value) {},
+          initialValue: 'SPIKERS',
+          hintText: 'Enter team name',
+          autofocus: true,
+        ),
+        FDTextField(
+          id: 'name-focused',
+          label: 'FF',
+          onChanged: (value) {},
+          initialValue: 'SPIKERS',
+          hintText: 'Enter team name',
+          autofocus: true,
+        ),
       ],
     );
   }
 }
+
+final predefined = [
+  FlowinDesignColors.neutral200,
+  Colors.yellow,
+  Colors.green,
+  Colors.blue,
+  Colors.purple,
+  Colors.red,
+];
 
 class _ColorPickers extends StatelessWidget {
   const _ColorPickers();
 
   @override
   Widget build(BuildContext context) {
-    final predefined = [
-      FlowinDesignColors.neutral200,
-      Colors.yellow,
-      Colors.green,
-      Colors.blue,
-      Colors.purple,
-      Colors.red,
-    ];
-
     return Column(
       spacing: FlowinDesignSpace.space400,
       children: [
@@ -114,6 +134,32 @@ class _ColorPickers extends StatelessWidget {
           predefinedColors: predefined,
           onColorChanged: (color) {
             debugPrint('selectedPreset.onColorChanged($color)');
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _CombinedFields extends StatelessWidget {
+  const _CombinedFields();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: FlowinDesignSpace.space400,
+      children: [
+        FDTextField(
+          id: 'name-empty',
+          label: 'Name',
+          onChanged: (value) {},
+          hintText: 'Enter team name',
+        ),
+        FDColorPickerField(
+          id: 'default',
+          predefinedColors: predefined,
+          onColorChanged: (color) {
+            debugPrint('default.onColorChanged($color)');
           },
         ),
       ],

--- a/lib/src/components/components.dart
+++ b/lib/src/components/components.dart
@@ -16,6 +16,7 @@ export 'color_picker/fd_color_radial_button.dart';
 export 'dividers/fd_divider.dart';
 export 'input_fields/fd_color_picker_field.dart';
 export 'input_fields/fd_input_field.dart';
+export 'input_fields/fd_input_field_constants.dart';
 export 'input_fields/fd_text_field.dart';
 export 'tabs/fd_tab_item.dart';
 export 'tabs/fd_tabs.dart';

--- a/lib/src/components/input_fields/fd_input_field.dart
+++ b/lib/src/components/input_fields/fd_input_field.dart
@@ -2,15 +2,6 @@ import 'package:flowin_design/flowin_design.dart';
 import 'package:flutter/material.dart';
 
 /// @no-doc
-const double fdInputFieldMinHeight = FlowinDesignSpace.space1600;
-
-/// @no-doc
-const double fdInputFieldLabelWidth = FlowinDesignSpace.space1000;
-
-/// @no-doc
-const double fdInputFieldContentMaxHeight = FlowinDesignSpace.space1000;
-
-/// @no-doc
 class FDInputField extends StatelessWidget {
   /// @no-doc
   const FDInputField({

--- a/lib/src/components/input_fields/fd_input_field.dart
+++ b/lib/src/components/input_fields/fd_input_field.dart
@@ -2,11 +2,21 @@ import 'package:flowin_design/flowin_design.dart';
 import 'package:flutter/material.dart';
 
 /// @no-doc
+const double fdInputFieldMinHeight = FlowinDesignSpace.space1600;
+
+/// @no-doc
+const double fdInputFieldLabelWidth = FlowinDesignSpace.space1000;
+
+/// @no-doc
+const double fdInputFieldContentMaxHeight = FlowinDesignSpace.space1000;
+
+/// @no-doc
 class FDInputField extends StatelessWidget {
   /// @no-doc
   const FDInputField({
     required this.label,
     required this.child,
+    this.labelWidth = fdInputFieldLabelWidth,
     super.key,
   });
 
@@ -15,6 +25,9 @@ class FDInputField extends StatelessWidget {
 
   /// @no-doc
   final Widget child;
+
+  /// @no-doc
+  final double labelWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -26,27 +39,33 @@ class FDInputField extends StatelessWidget {
     final labelTextStyle = textTheme.labelMedium?.copyWith(
       color: colorScheme.onSurface,
     );
-    const minHeight = FlowinDesignSpace.space1000;
 
     return FDCard(
-      borderRadius: const FDCardBorderRadius.all(FlowinDesignRadius.radius400),
+      borderRadius: const FDCardBorderRadius.all(
+        FlowinDesignRadius.radius400,
+      ),
+      size: const Size.fromHeight(fdInputFieldMinHeight),
       backgroundColor: Colors.transparent,
       borderSide: BorderSide(color: borderColor),
       padding: const EdgeInsets.symmetric(
         vertical: FlowinDesignSpace.space300,
         horizontal: FlowinDesignSpace.space400,
       ),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: minHeight),
+      child: SizedBox(
+        height: fdInputFieldContentMaxHeight,
         child: Row(
           spacing: FlowinDesignSpace.space250,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(label, style: labelTextStyle),
             SizedBox(
-              height: minHeight,
-              child: FDVerticalDivider(color: borderColor),
+              width: labelWidth,
+              child: Text(
+                label,
+                style: labelTextStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
+            FDVerticalDivider(color: borderColor),
             Expanded(
               child: child,
             ),

--- a/lib/src/components/input_fields/fd_input_field_constants.dart
+++ b/lib/src/components/input_fields/fd_input_field_constants.dart
@@ -1,0 +1,13 @@
+import 'package:flowin_design/flowin_design.dart';
+
+/// @no-doc
+const double fdInputFieldMinHeight = FlowinDesignSpace.space1600;
+
+/// @no-doc
+const double fdInputFieldLabelWidth = FlowinDesignSpace.space1000;
+
+/// @no-doc
+const double fdInputFieldContentMaxHeight = FlowinDesignSpace.space1000;
+
+/// @no-doc
+const fdTextFieldMaxLines = 1;

--- a/lib/src/components/input_fields/fd_text_field.dart
+++ b/lib/src/components/input_fields/fd_text_field.dart
@@ -1,4 +1,4 @@
-import 'package:flowin_design/src/components/input_fields/fd_input_field.dart';
+import 'package:flowin_design/src/components/components.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -13,6 +13,7 @@ class FDTextField extends StatelessWidget {
     this.autofocus = false,
     this.hintText,
     this.inputFormatters,
+    this.maxLines = fdTextFieldMaxLines,
     super.key,
   });
 
@@ -35,6 +36,9 @@ class FDTextField extends StatelessWidget {
   final String? hintText;
 
   /// @no-doc
+  final int maxLines;
+
+  /// @no-doc
   final List<TextInputFormatter>? inputFormatters;
 
   @override
@@ -50,15 +54,16 @@ class FDTextField extends StatelessWidget {
       key: Key('fd-text-field-$id'),
       label: label,
       child: TextFormField(
-        autofocus: autofocus,
-        inputFormatters: inputFormatters,
-        decoration: InputDecoration(
-          hintText: hintText,
-          border: InputBorder.none,
-          hintStyle: hintTextStyle,
-        ),
-        onChanged: onChanged,
         initialValue: initialValue,
+        onChanged: onChanged,
+        autofocus: autofocus,
+        maxLines: maxLines,
+        inputFormatters: inputFormatters,
+        decoration: InputDecoration.collapsed(
+          hintText: hintText,
+          hintStyle: hintTextStyle,
+          fillColor: Colors.blueAccent.shade100,
+        ),
       ),
     );
   }


### PR DESCRIPTION
# Overview

- Add `FDInputField` label width attribute. Defaults to `fdInputFieldLabelWidth` constant.
  - Now fields will use overflow ellipsis for texts provided.
- Add `InputDecoration.collapsed` to `FDTextField` in order to match input field content height.
- Add `Combined` group view on `Input Fields` example app showcase.
- Add new constants file for input fields.

Closes #12 

# Showcase

### Field labels now have constrained width

<img width="1552" height="987" alt="Screenshot 2025-09-08 at 13 06 53" src="https://github.com/user-attachments/assets/dc78e406-a208-471a-942a-857f68743685" />

### Combined group

<img width="1552" height="987" alt="Screenshot 2025-09-08 at 13 06 48" src="https://github.com/user-attachments/assets/3ebf4599-cdb6-4562-8fac-31c468a6c147" />

