### PR TITLE
refactor: add input field label decoration

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -23,6 +23,7 @@
     "Flowin’s",
     "squircle",
     "Extralight",
-    "Farbe"
+    "Farbe",
+    "Nombre"
   ]
 }

--- a/example/lib/modules/components/input_fields.dart
+++ b/example/lib/modules/components/input_fields.dart
@@ -69,7 +69,7 @@ class _TextFields extends StatelessWidget {
         ),
         FDTextField(
           id: 'name-focused',
-          label: 'Name',
+          label: 'Nombre',
           onChanged: (value) {},
           initialValue: 'SPIKERS',
           hintText: 'Enter team name',
@@ -102,7 +102,7 @@ final predefined = [
   Colors.green,
   Colors.blue,
   Colors.purple,
-  Colors.red,
+  //Colors.red,
 ];
 
 class _ColorPickers extends StatelessWidget {

--- a/lib/src/components/input_fields/fd_color_picker_field.dart
+++ b/lib/src/components/input_fields/fd_color_picker_field.dart
@@ -11,6 +11,7 @@ class FDColorPickerField extends StatefulWidget {
     this.label,
     this.initialColor,
     this.onColorChanged,
+    this.labelWidth,
     super.key,
   });
 
@@ -22,6 +23,9 @@ class FDColorPickerField extends StatefulWidget {
 
   /// @no-doc
   final String? label;
+
+  /// @no-doc
+  final double? labelWidth;
 
   /// @no-doc
   final List<Color> predefinedColors;
@@ -55,6 +59,7 @@ class _FDColorPickerFieldState extends State<FDColorPickerField> {
     return FDInputField(
       key: Key('fd-color-picker-field-${widget.id}'),
       label: widget.label ?? 'Color',
+      labelWidth: widget.labelWidth,
       child: FDInlineColorPicker(
         selectedColor: _selectedColor,
         predefinedColors: widget.predefinedColors,

--- a/lib/src/components/input_fields/fd_color_picker_field.dart
+++ b/lib/src/components/input_fields/fd_color_picker_field.dart
@@ -11,7 +11,7 @@ class FDColorPickerField extends StatefulWidget {
     this.label,
     this.initialColor,
     this.onColorChanged,
-    this.labelWidth,
+    this.labelDecoration,
     super.key,
   });
 
@@ -25,7 +25,7 @@ class FDColorPickerField extends StatefulWidget {
   final String? label;
 
   /// @no-doc
-  final double? labelWidth;
+  final FDInputFieldLabelDecoration? labelDecoration;
 
   /// @no-doc
   final List<Color> predefinedColors;
@@ -59,7 +59,7 @@ class _FDColorPickerFieldState extends State<FDColorPickerField> {
     return FDInputField(
       key: Key('fd-color-picker-field-${widget.id}'),
       label: widget.label ?? 'Color',
-      labelWidth: widget.labelWidth,
+      labelDecoration: widget.labelDecoration,
       child: FDInlineColorPicker(
         selectedColor: _selectedColor,
         predefinedColors: widget.predefinedColors,

--- a/lib/src/components/input_fields/fd_input_field.dart
+++ b/lib/src/components/input_fields/fd_input_field.dart
@@ -18,7 +18,7 @@ class FDInputField extends StatelessWidget {
   final Widget child;
 
   /// @no-doc
-  final double labelWidth;
+  final double? labelWidth;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/components/input_fields/fd_input_field.dart
+++ b/lib/src/components/input_fields/fd_input_field.dart
@@ -7,7 +7,7 @@ class FDInputField extends StatelessWidget {
   const FDInputField({
     required this.label,
     required this.child,
-    this.labelWidth = fdInputFieldLabelWidth,
+    this.labelDecoration,
     super.key,
   });
 
@@ -18,7 +18,7 @@ class FDInputField extends StatelessWidget {
   final Widget child;
 
   /// @no-doc
-  final double? labelWidth;
+  final FDInputFieldLabelDecoration? labelDecoration;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +29,11 @@ class FDInputField extends StatelessWidget {
     final borderColor = colorScheme.outlineVariant;
     final labelTextStyle = textTheme.labelMedium?.copyWith(
       color: colorScheme.onSurface,
+    );
+
+    final effectiveLabelDecoration = FDInputFieldLabelDecoration(
+      textAlign: labelDecoration?.textAlign ?? TextAlign.center,
+      width: labelDecoration?.width ?? fdInputFieldLabelWidth,
     );
 
     return FDCard(
@@ -49,9 +54,10 @@ class FDInputField extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             SizedBox(
-              width: labelWidth,
+              width: effectiveLabelDecoration.width,
               child: Text(
                 label,
+                textAlign: effectiveLabelDecoration.textAlign,
                 style: labelTextStyle,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -63,6 +69,32 @@ class FDInputField extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// @no-doc
+class FDInputFieldLabelDecoration {
+  /// @no-doc
+  const FDInputFieldLabelDecoration({
+    required this.textAlign,
+    required this.width,
+  });
+
+  /// @no-doc
+  final TextAlign? textAlign;
+
+  /// @no-doc
+  final double? width;
+
+  /// @no-doc
+  FDInputFieldLabelDecoration copyWith({
+    TextAlign? textAlign,
+    double? width,
+  }) {
+    return FDInputFieldLabelDecoration(
+      textAlign: textAlign,
+      width: width,
     );
   }
 }

--- a/lib/src/components/input_fields/fd_input_field_constants.dart
+++ b/lib/src/components/input_fields/fd_input_field_constants.dart
@@ -4,7 +4,7 @@ import 'package:flowin_design/flowin_design.dart';
 const double fdInputFieldMinHeight = FlowinDesignSpace.space1600;
 
 /// @no-doc
-const double fdInputFieldLabelWidth = FlowinDesignSpace.space1000;
+const double fdInputFieldLabelWidth = FlowinDesignSpace.space1400;
 
 /// @no-doc
 const double fdInputFieldContentMaxHeight = FlowinDesignSpace.space1000;

--- a/lib/src/components/input_fields/fd_text_field.dart
+++ b/lib/src/components/input_fields/fd_text_field.dart
@@ -14,7 +14,7 @@ class FDTextField extends StatelessWidget {
     this.hintText,
     this.inputFormatters,
     this.maxLines = fdTextFieldMaxLines,
-    this.labelWidth,
+    this.labelDecoration,
     super.key,
   });
 
@@ -40,7 +40,7 @@ class FDTextField extends StatelessWidget {
   final int maxLines;
 
   /// @no-doc
-  final double? labelWidth;
+  final FDInputFieldLabelDecoration? labelDecoration;
 
   /// @no-doc
   final List<TextInputFormatter>? inputFormatters;
@@ -57,7 +57,7 @@ class FDTextField extends StatelessWidget {
     return FDInputField(
       key: Key('fd-text-field-$id'),
       label: label,
-      labelWidth: labelWidth,
+      labelDecoration: labelDecoration,
       child: TextFormField(
         initialValue: initialValue,
         onChanged: onChanged,

--- a/lib/src/components/input_fields/fd_text_field.dart
+++ b/lib/src/components/input_fields/fd_text_field.dart
@@ -14,6 +14,7 @@ class FDTextField extends StatelessWidget {
     this.hintText,
     this.inputFormatters,
     this.maxLines = fdTextFieldMaxLines,
+    this.labelWidth,
     super.key,
   });
 
@@ -39,6 +40,9 @@ class FDTextField extends StatelessWidget {
   final int maxLines;
 
   /// @no-doc
+  final double? labelWidth;
+
+  /// @no-doc
   final List<TextInputFormatter>? inputFormatters;
 
   @override
@@ -53,6 +57,7 @@ class FDTextField extends StatelessWidget {
     return FDInputField(
       key: Key('fd-text-field-$id'),
       label: label,
+      labelWidth: labelWidth,
       child: TextFormField(
         initialValue: initialValue,
         onChanged: onChanged,


### PR DESCRIPTION
## Overview

Introduce `FDInputFieldLabelDecoration` class. To customize `textAlign` and `width` for the input field label.
- `textAlign` defaults to `TextAlign.center`
- `width` defaults to `fdInputFieldLabelWidth`

Relates to #12 

## Showcase

### Text group view

<img width="1552" height="987" alt="Screenshot 2025-09-08 at 14 09 59" src="https://github.com/user-attachments/assets/3548734e-21c5-41a9-a2fa-fa04fbbc4bf8" />

### Combined group view

<img width="1552" height="987" alt="Screenshot 2025-09-08 at 14 10 03" src="https://github.com/user-attachments/assets/56a1811b-1e4b-42d8-83e2-e6d3c9e94410" />
